### PR TITLE
Softened boto dependency as per README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='cloudwatchmon',
       keywords="monitoring cloudwatch amazon web services aws ec2",
       zip_safe=True,
       packages=find_packages(),
-      install_requires=['boto==2.38.0'],
+      install_requires=['boto>=2.33.0'],
       entry_points={'console_scripts': [
           'mon-get-instance-stats.py=cloudwatchmon.cli.get_instance_stats:main',
           'mon-put-instance-stats.py=cloudwatchmon.cli.put_instance_stats:main',


### PR DESCRIPTION
The boto dependency doesn't play nicely with dependencies from other libraries as it's fixed to an exact version (due to having copied it from a `requirements.txt` file). It's better to explicitly put in a range (I used >=2.33.0 as the README says) and then I have some flexibility to install this alongside stricter dependencies on boto.
