### PR TITLE
`argparse` is required to run the scripts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='cloudwatchmon',
       keywords="monitoring cloudwatch amazon web services aws ec2",
       zip_safe=True,
       packages=find_packages(),
-      install_requires=['boto>=2.33.0'],
+      install_requires=['boto>=2.33.0','argparse'],
       entry_points={'console_scripts': [
           'mon-get-instance-stats.py=cloudwatchmon.cli.get_instance_stats:main',
           'mon-put-instance-stats.py=cloudwatchmon.cli.put_instance_stats:main',


### PR DESCRIPTION
If you download the project, run `python setup.py install`, and then try to run the `mon-get-instance-stats.py` script, you'll end up getting a `ImportError: No module named argparse`.  Adding `argparse` to the `install_requires` will ensure that the required module is installed.
