### PR TITLE
Fix Python 2.7 CentOS issue by requiring argparse only in Py2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def readme():
 requires = ['boto>=2.33.0',]
 
 
- if sys.version_info == (2, 6):
+ if sys.version_info[:2] == (2, 6):
      requires += ['argparse']
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from cloudwatchmon import VERSION
 import os.path
-
+import sys
 from setuptools import find_packages, setup
 
 
@@ -10,6 +10,13 @@ def readme():
     if os.path.exists(path):
         with open(path) as f:
             return f.read()
+
+
+requires = ['boto>=2.33.0',]
+
+
+ if sys.version_info == (2, 6):
+     requires += ['argparse']
 
 
 setup(name='cloudwatchmon',
@@ -23,7 +30,7 @@ setup(name='cloudwatchmon',
       keywords="monitoring cloudwatch amazon web services aws ec2",
       zip_safe=True,
       packages=find_packages(),
-      install_requires=['boto>=2.33.0', 'argparse'],
+      install_requires=requires,
       entry_points={'console_scripts': [
           'mon-get-instance-stats.py=cloudwatchmon.cli.get_instance_stats:main',
           'mon-put-instance-stats.py=cloudwatchmon.cli.put_instance_stats:main',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,4 @@
+[tox]
+envlist = py26,py27,py33,py34,py35,py36
+[testenv]
+commands=mon-get-instance-stats.py --version


### PR DESCRIPTION
See my comments in https://github.com/osiegmar/cloudwatch-mon-scripts-python/pull/9