### PR TITLE
Include "Slab" memory as available memory.

### DIFF
--- a/cloudwatchmon/cli/put_instance_stats.py
+++ b/cloudwatchmon/cli/put_instance_stats.py
@@ -51,6 +51,7 @@ class MemData:
         self.mem_total = mem_info['MemTotal']
         self.mem_free = mem_info['MemFree']
         self.mem_cached = mem_info['Cached']
+        self.mem_slab = mem_info['Slab']
         self.mem_buffers = mem_info['Buffers']
         self.swap_total = mem_info['SwapTotal']
         self.swap_free = mem_info['SwapFree']
@@ -76,7 +77,7 @@ class MemData:
     def mem_avail(self):
         mem_avail = self.mem_free
         if not self.mem_used_incl_cache_buff:
-            mem_avail += self.mem_cached + self.mem_buffers
+            mem_avail += self.mem_cached + self.mem_buffers + self.mem_slab
 
         return mem_avail
 


### PR DESCRIPTION
Hi guys.

I have a system with 8GB of RAM, which currently shows 5.9GB as buff/cache (generally considered "available" RAM):

~~~
[root@ip-10-11-xxx-xxx cli]# free -k
              total        used        free      shared  buff/cache   available
Mem:        8008348     1879104      132168        3024     5997076     5720528
Swap:             0           0           0
[root@ip-10-11-xxx-xxx cli]#
~~~

Yet mon-put-instance-stats.py (without --mem-used-incl-cache-buff) is reporting the memory utilisation at 88%:

~~~
[root@ip-10-11-xxx-xxx /]# mon-put-instance-stats.py --mem-util --mem-used --swap-util --swap-use --verbose
Working in verbose mode
Boto-Version: 2.45.0
Instance metadata: {XXXXXX}
Request:
MemoryUtilization: 88.2313306065 Percent ({'InstanceId': 'i-xxxx'})
MemoryUsed: 6900.265625 Megabytes ({'InstanceId': 'i-xxxx'})
SwapUtilization: 0 Percent ({'InstanceId': 'i-xxxx'})
SwapUsed: 0.0 Megabytes ({'InstanceId': 'i-xxxx'})
~~~

The memory used should be more like 22%.

The reason for the discrepancy is that the "cache" value also includes the Slab memory.

From "man free":

~~~
       cache  Memory used by the page cache and slabs (Cached and Slab in /proc/meminfo)
~~~

This PR ensures that the "Slab" entry in /proc/meminfo is also included in the memory available (alongside cache and buffers).

Note:  If the --mem-used-incl-cache-buff argument is used, the memory utilisation will consider the Slab as used memory as it does currently.

After the patch is applied:

~~~
[root@ip-10-11-xxx-xxx cli]# mon-put-instance-stats.py --mem-util --mem-used --swap-util --swap-use --verbose
Working in verbose mode
Boto-Version: 2.45.0
Instance metadata: {xxxx}
Request:
MemoryUtilization: 21.5269865895 Percent ({'InstanceId': 'i-xxxx'})
MemoryUsed: 1683.55078125 Megabytes ({'InstanceId': 'i-xxxx'})
SwapUtilization: 0 Percent ({'InstanceId': 'i-xxxx'})
SwapUsed: 0.0 Megabytes ({'InstanceId': 'i-xxxx'})
~~~



