### PR TITLE
Use 'MemAvailable' metric on Linux 3.x kernels

### DIFF
--- a/cloudwatchmon/cli/put_instance_stats.py
+++ b/cloudwatchmon/cli/put_instance_stats.py
@@ -50,6 +50,7 @@ class MemData:
         mem_info = self.__gather_mem_info()
         self.mem_total = mem_info['MemTotal']
         self.mem_free = mem_info['MemFree']
+        self.mem_available = mem_info.get('MemAvailable') # Linux >= 3.14
         self.mem_cached = mem_info['Cached']
         self.mem_buffers = mem_info['Buffers']
         self.swap_total = mem_info['SwapTotal']
@@ -74,9 +75,14 @@ class MemData:
         return self.mem_total - self.mem_avail()
 
     def mem_avail(self):
-        mem_avail = self.mem_free
-        if not self.mem_used_incl_cache_buff:
-            mem_avail += self.mem_cached + self.mem_buffers
+        # Linux 3.14 kernel added 'MemAvailable' to /proc/meminfo
+        if self.mem_available:
+            mem_avail = self.mem_available
+        else:
+            mem_avail = self.mem_free + self.mem_cached + self.mem_buffers
+
+        if self.mem_used_incl_cache_buff:
+            mem_avail -= self.mem_cached + self.mem_buffers        
 
         return mem_avail
 


### PR DESCRIPTION
Hi guys,

Yesterday I raise a pull request to take the "Slab" memory into account when calculating available memory because mon-put-instance-stats.py on my RHEL 7. 3 system was showing 88% memory used, when "free" reported it was more like 22%.

This is needed because "man free" on RHEL 7:

~~~
       cache  Memory used by the page cache and slabs (Cached and Slab in /proc/meminfo)
~~~

However, after a bit more testing I noticed the behavior seems to be different on Linux 2.6 kernels (i.e. RHEL 6).

This new PR uses a new Linux 3.x metric in /proc/meminfo "MemAvailable" instead of trying to calculate the available memory.  "MemAvailable" also takes the reclaimable Slab memory into account which solves my problem of inaccurate reporting on RHEL7.

If the "MemAvailable" metric is not available, it reverts back to the old method.  This ensures 2.x kernels should work the same way as before, but 3.x kernels will take the Slab memory into account.

On my test system, before:

~~~
[root@ip-10-11-xxx-xxx cli]# free -k
              total        used        free      shared  buff/cache   available
Mem:        8008348     1960684      140660        3056     5907004     5626244
Swap:             0           0           0
[root@ip-10-11-xxx-xxx cli]#
[root@ip-10-11-xxx-xxx cli]# mon-put-instance-stats.py --mem-util --mem-used --verbose | grep ^Mem
MemoryUtilization: 86.3316629098 Percent ({'InstanceId': 'i-xxxxxxxxxxxxxxxxxx'})
MemoryUsed: 6751.69921875 Megabytes ({'InstanceId': 'i-xxxxxxxxxxxxxxxxx'})
~~~

After:

~~~
[root@ip-10-11-xxx-xxx cli]# grep Slab /proc/meminfo
Slab:            4919484 kB
[root@ip-10-11-xxx-xxx cli]# free -k
              total        used        free      shared  buff/cache   available
Mem:        8008348     1882452      193032        3056     5932864     5704376
Swap:             0           0           0
[root@ip-10-11-xxx-xxx cli]# mon-put-instance-stats.py --mem-util --mem-used --verbose | grep ^Mem
MemoryUtilization: 28.9638262473 Percent ({'InstanceId': 'i-xxxxxxxxxxxxxxxxxxx'})
MemoryUsed: 2265.16015625 Megabytes ({'InstanceId': 'i-xxxxxxxxxxxxxxxxxx'})
~~~

Thanks, 
Tim.